### PR TITLE
Bugfix/slstm zo smoother

### DIFF
--- a/examples/time_series_smoother.py
+++ b/examples/time_series_smoother.py
@@ -80,7 +80,9 @@ def main(num_epochs: int = 50, batch_size: int = 1, sigma_v: float = 1):
         sigma_v = exponential_scheduler(
             curr_v=sigma_v, min_v=0.3, decaying_factor=0.99, curr_iter=epoch
         )
-        var_y = np.full((batch_size * len(output_col),), sigma_v**2, dtype=np.float32)
+        var_y = np.full(
+            (batch_size * len(output_col),), sigma_v**2, dtype=np.float32
+        )
         y_train = []
 
         # for x, y in batch_iter:
@@ -125,7 +127,7 @@ def main(num_epochs: int = 50, batch_size: int = 1, sigma_v: float = 1):
         # Smoother
         mu_zo_smooth, var_zo_smooth = net.smoother()
         zo_smooth_std = np.array(var_zo_smooth) ** 0.5
-        mu_sequence = mu_zo_smooth[:input_seq_len]
+        mu_sequence = np.ones(input_seq_len, dtype=np.float32)
 
         # # Figures for each epoch
         t = np.arange(len(mu_zo_smooth))
@@ -176,7 +178,9 @@ def main(num_epochs: int = 50, batch_size: int = 1, sigma_v: float = 1):
     mu_preds = normalizer.unstandardize(
         mu_preds, train_dtl.x_mean[output_col], train_dtl.x_std[output_col]
     )
-    std_preds = normalizer.unstandardize_std(std_preds, train_dtl.x_std[output_col])
+    std_preds = normalizer.unstandardize_std(
+        std_preds, train_dtl.x_std[output_col]
+    )
 
     y_test = normalizer.unstandardize(
         y_test, train_dtl.x_mean[output_col], train_dtl.x_std[output_col]

--- a/include/data_struct.h
+++ b/include/data_struct.h
@@ -104,57 +104,13 @@ class BaseHiddenStates {
 
 class SmoothingHiddenStates : public BaseHiddenStates {
    public:
-    std::vector<float> mu_h_prev;
-    std::vector<float> cov_hh;
     int num_timesteps = 0;
 
     // Constructor with initialization
     SmoothingHiddenStates(size_t n, size_t m, int num_timesteps)
-        : BaseHiddenStates(n, m),
-          mu_h_prev(n, 0.0f),
-          cov_hh(n * n, 0.0f),
-          num_timesteps(num_timesteps) {}
-
-    // Default constructor
-    SmoothingHiddenStates() = default;
-    ~SmoothingHiddenStates() = default;
-
-    // Custom copy constructor
-    SmoothingHiddenStates(const SmoothingHiddenStates &other)
-        : BaseHiddenStates(other),
-          cov_hh(other.cov_hh),
-          mu_h_prev(other.mu_h_prev) {}
-
-    // Custom copy assignment operator
-    SmoothingHiddenStates &operator=(const SmoothingHiddenStates &other) {
-        if (this != &other) {
-            BaseHiddenStates::operator=(other);
-            cov_hh = other.cov_hh;
-            mu_h_prev = other.mu_h_prev;
-        }
-        return *this;
-    }
-
-    // Move constructor
-    SmoothingHiddenStates(SmoothingHiddenStates &&other) noexcept
-        : BaseHiddenStates(std::move(other)),
-          cov_hh(std::move(other.cov_hh)),
-          mu_h_prev(std::move(other.mu_h_prev)) {}
-
-    // Move assignment operator
-    SmoothingHiddenStates &operator=(SmoothingHiddenStates &&other) noexcept {
-        if (this != &other) {
-            BaseHiddenStates::operator=(std::move(other));
-            cov_hh = std::move(other.cov_hh);
-            mu_h_prev = std::move(other.mu_h_prev);
-        }
-        return *this;
-    }
+        : BaseHiddenStates(n, m), num_timesteps(num_timesteps) {}
 
     std::string get_name() const override { return "SmoothingHiddenStates"; }
-    void set_size(size_t new_size, size_t new_block_size) override;
-    void copy_from(const BaseHiddenStates &source, int num_data = -1) override;
-    void swap(BaseHiddenStates &other) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/data_struct.h
+++ b/include/data_struct.h
@@ -288,7 +288,7 @@ class SmoothSLSTM {
     size_t num_timesteps = 0;
     std::vector<float> mu_h_priors, var_h_priors, mu_c_priors, var_c_priors,
         mu_h_posts, var_h_posts, mu_c_posts, var_c_posts, mu_h_smooths,
-        var_h_smooths, mu_c_smooths, var_c_smooths, cov_hc, cov_cc;
+        var_h_smooths, mu_c_smooths, var_c_smooths, cov_hc, cov_cc, cov_hh;
 
     SmoothSLSTM(size_t num_states, size_t num_timesteps);
     SmoothSLSTM();

--- a/include/slinear_layer.h
+++ b/include/slinear_layer.h
@@ -36,7 +36,8 @@ class SLinear : public Linear {
                   BaseDeltaStates &output_delta_states,
                   BaseTempStates &temp_states, bool state_udapte) override;
 
-    void smoother();
+    void smoother(const std::vector<float> &prev_mu_h_smooths,
+                  const std::vector<float> &prev_var_h_smooths);
 
     void print_summary() const;
 };

--- a/plot_smooth_states.py
+++ b/plot_smooth_states.py
@@ -1,6 +1,6 @@
-import pandas as pd
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 
 # --- 1. Load the raw CSV (no header) ---
 # Make sure your CSV is named 'state_values.csv' and is in the same folder as this script.
@@ -17,7 +17,7 @@ mu_df = df_raw[df_raw[1].str.startswith("mu")]
 
 # --- 4. Plot ---
 plt.figure(figsize=(8, 4))
-cmap = plt.get_cmap('winter')
+cmap = plt.get_cmap("winter")
 colors = cmap(np.linspace(0, 1, len(mu_df)))
 
 for color, (_, row) in zip(colors, mu_df.iterrows()):
@@ -26,7 +26,7 @@ for color, (_, row) in zip(colors, mu_df.iterrows()):
     print(len(values), len(time_steps), label)
     plt.plot(time_steps, values, color=color, label=label)
 
-plt.axvline(x=24, color='red', linestyle='--', linewidth=1)
+plt.axvline(x=24, color="red", linestyle="--", linewidth=1)
 plt.xlabel("Time Step")
 plt.ylabel("Value")
 plt.title("Evolution of μ Priors, Posteriors and Smoothed Over Time")

--- a/src/data_struct.cpp
+++ b/src/data_struct.cpp
@@ -520,4 +520,9 @@ void SmoothSLSTM::reset_zeros()
     if (cov_cc.size() != num_states * num_timesteps)
         cov_cc.resize(num_states * num_timesteps);
     for (auto& val : cov_cc) val = 0;
+
+    // Resize and reset cov_hh
+    if (cov_hh.size() != num_states * num_states * num_timesteps)
+        cov_hh.resize(num_states * num_states * num_timesteps);
+    for (auto& val : cov_hh) val = 0;
 }

--- a/src/data_struct.cpp
+++ b/src/data_struct.cpp
@@ -94,38 +94,6 @@ void BaseHiddenStates::copy_from(const BaseHiddenStates& source, int num_data)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Base Smoothing Hidden States
-////////////////////////////////////////////////////////////////////////////////
-void SmoothingHiddenStates::set_size(size_t new_size, size_t new_block_size) {
-    // Set the size of BaseHiddenStates variables
-    BaseHiddenStates::set_size(new_size, new_block_size);
-    this->cov_hh.resize(this->size, 0.0f);
-    this->mu_h_prev.resize(this->size * this->size, 0.0f);
-}
-
-//  Override the copy_from method
-void SmoothingHiddenStates::copy_from(const BaseHiddenStates& source,
-                                      int num_data) {
-    BaseHiddenStates::copy_from(source, num_data);
-
-    const SmoothingHiddenStates* source_other =
-        dynamic_cast<const SmoothingHiddenStates*>(&source);
-
-    this->cov_hh = source_other->cov_hh;
-    this->mu_h_prev = source_other->mu_h_prev;
-    this->num_timesteps = source_other->num_timesteps;
-}
-
-//  Override the swap method
-void SmoothingHiddenStates::swap(BaseHiddenStates& other) {
-    SmoothingHiddenStates* smooth_other =
-        dynamic_cast<SmoothingHiddenStates*>(&other);
-    std::swap(this->cov_hh, smooth_other->cov_hh);
-    std::swap(this->mu_h_prev, smooth_other->mu_h_prev);
-    std::swap(this->num_timesteps, smooth_other->num_timesteps);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Base Delta States
 ////////////////////////////////////////////////////////////////////////////////
 BaseDeltaStates::BaseDeltaStates(size_t n, size_t m, int device_idx)

--- a/src/lstm_layer.cpp
+++ b/src/lstm_layer.cpp
@@ -1523,6 +1523,11 @@ void LSTM::set_LSTM_states(const std::vector<float> &mu_h,
     this->lstm_states.var_h_prior = var_h;
     this->lstm_states.mu_c_prior = mu_c;
     this->lstm_states.var_c_prior = var_c;
+
+    this->lstm_states.mu_h_prev = mu_h;
+    this->lstm_states.var_h_prev = var_h;
+    this->lstm_states.mu_c_prev = mu_c;
+    this->lstm_states.var_c_prev = var_c;
 }
 
 #ifdef USE_CUDA

--- a/src/lstm_layer.cpp
+++ b/src/lstm_layer.cpp
@@ -1503,26 +1503,26 @@ void LSTM::backward(BaseDeltaStates &input_delta_states,
 // retrieve the cell state and hidden state
 std::tuple<std::vector<float>, std::vector<float>, std::vector<float>,
            std::vector<float>>
-LSTM::get_LSTM_states() const {
+LSTM::get_LSTM_states()
+    /*
+     */
+    const {
     return std::make_tuple(lstm_states.mu_h_prior, lstm_states.var_h_prior,
                            lstm_states.mu_c_prior, lstm_states.var_c_prior);
 }
+
 // set the cell state and hidden state
 void LSTM::set_LSTM_states(const std::vector<float> &mu_h,
                            const std::vector<float> &var_h,
                            const std::vector<float> &mu_c,
-                           const std::vector<float> &var_c) {
-    // TODO: check for better way to set the states SLSTM vs LSTM
-    // needed for LSTM as prior will be pushed to prev in forward
+                           const std::vector<float> &var_c)
+/*
+ */
+{
     this->lstm_states.mu_h_prior = mu_h;
     this->lstm_states.var_h_prior = var_h;
     this->lstm_states.mu_c_prior = mu_c;
     this->lstm_states.var_c_prior = var_c;
-    // can directly set to the prev states in SLSTM
-    this->lstm_states.mu_h_prev = mu_h;
-    this->lstm_states.var_h_prev = var_h;
-    this->lstm_states.mu_c_prev = mu_c;
-    this->lstm_states.var_c_prev = var_c;
 }
 
 #ifdef USE_CUDA
@@ -1541,7 +1541,10 @@ std::unique_ptr<BaseLayer> LSTM::to_cuda(int device_idx) {
 }
 #endif
 
-void LSTM::preinit_layer() {
+void LSTM::preinit_layer()
+/*
+ */
+{
     if (this->num_weights == 0) {
         this->get_number_param();
         this->init_weight_bias();

--- a/src/lstm_layer.cpp
+++ b/src/lstm_layer.cpp
@@ -1519,9 +1519,9 @@ void LSTM::set_LSTM_states(const std::vector<float> &mu_h,
     this->lstm_states.mu_c_prior = mu_c;
     this->lstm_states.var_c_prior = var_c;
     // can directly set to the prev states in SLSTM
-    this->lstm_states.mu_h_prev  = mu_h;
+    this->lstm_states.mu_h_prev = mu_h;
     this->lstm_states.var_h_prev = var_h;
-    this->lstm_states.mu_c_prev  = mu_c;
+    this->lstm_states.mu_c_prev = mu_c;
     this->lstm_states.var_c_prev = var_c;
 }
 

--- a/src/sequential.cpp
+++ b/src/sequential.cpp
@@ -803,7 +803,10 @@ Sequential::get_outputs()
 }
 
 std::tuple<pybind11::array_t<float>, pybind11::array_t<float>>
-Sequential::get_outputs_smoother() {
+Sequential::get_outputs_smoother()
+/*
+ */
+{
     auto last_layer = dynamic_cast<SLinear *>(this->layers.back().get());
     auto py_mu_zo_smooths = pybind11::array_t<float>(
         last_layer->smooth_states.mu_zo_smooths.size(),
@@ -817,7 +820,10 @@ Sequential::get_outputs_smoother() {
 }
 
 std::tuple<pybind11::array_t<float>, pybind11::array_t<float>>
-Sequential::get_input_states() {
+Sequential::get_input_states()
+/*
+ */
+{
     // Check if input_state_update is enabled
     if (!this->input_state_update) {
         LOG(LogLevel::ERROR, "input_state_update is set to False.");
@@ -854,7 +860,10 @@ Sequential::get_input_states() {
 
 std::unordered_map<int, std::tuple<std::vector<float>, std::vector<float>,
                                    std::vector<float>, std::vector<float>>>
-Sequential::get_lstm_states(int time_step) const {
+Sequential::get_lstm_states(int time_step)
+    /*
+     */
+    const {
     std::unordered_map<int, std::tuple<std::vector<float>, std::vector<float>,
                                        std::vector<float>, std::vector<float>>>
         lstm_states;
@@ -896,7 +905,10 @@ Sequential::get_lstm_states(int time_step) const {
 void Sequential::set_lstm_states(
     const std::unordered_map<
         int, std::tuple<std::vector<float>, std::vector<float>,
-                        std::vector<float>, std::vector<float>>> &lstm_states) {
+                        std::vector<float>, std::vector<float>>> &lstm_states)
+/*
+ */
+{
     for (const auto &pair : lstm_states) {
         int layer_idx = pair.first;
         if (layer_idx >= 0 && layer_idx < static_cast<int>(layers.size()) &&

--- a/src/sequential.cpp
+++ b/src/sequential.cpp
@@ -415,6 +415,7 @@ std::tuple<std::vector<float>, std::vector<float>> Sequential::smoother()
  */
 {
     std::vector<float> mu_zo_smooths, var_zo_smooths;
+    std::vector<float> last_mu_h_smooths, last_var_h_smooths;
     // Hidden layers
     for (auto layer = this->layers.begin(); layer != this->layers.end();
          layer++) {
@@ -422,9 +423,12 @@ std::tuple<std::vector<float>, std::vector<float>> Sequential::smoother()
         if (current_layer->get_layer_type() == LayerType::SLSTM) {
             auto *slstm_layer = dynamic_cast<SLSTM *>(current_layer);
             slstm_layer->smoother();
+            // Capture hidden-state smooths for the next layer
+            last_mu_h_smooths = slstm_layer->smooth_states.mu_h_smooths;
+            last_var_h_smooths = slstm_layer->smooth_states.var_h_smooths;
         } else if (current_layer->get_layer_type() == LayerType::SLinear) {
             auto *slinear_layer = dynamic_cast<SLinear *>(current_layer);
-            slinear_layer->smoother();
+            slinear_layer->smoother(last_mu_h_smooths, last_var_h_smooths);
             mu_zo_smooths = slinear_layer->smooth_states.mu_zo_smooths;
             var_zo_smooths = slinear_layer->smooth_states.var_zo_smooths;
         }

--- a/src/slinear_layer.cpp
+++ b/src/slinear_layer.cpp
@@ -302,4 +302,7 @@ void SLinear::smoother(const std::vector<float> &prev_mu_h_smooths,
               this->var_w, this->mu_b, this->var_b, prev_mu_h_smooths,
               prev_var_h_smooths, this->smooth_states.mu_zo_smooths,
               this->smooth_states.var_zo_smooths);
+
+    this->print_summary();
+    this->time_step = 0;
 }

--- a/src/slinear_layer.cpp
+++ b/src/slinear_layer.cpp
@@ -307,6 +307,6 @@ void SLinear::smoother(const std::vector<float> &prev_mu_h_smooths,
               this->smooth_states.mu_zo_smooths,
               this->smooth_states.var_zo_smooths);
 
-    this->print_summary();
+    // this->print_summary();
     this->time_step = 0;
 }

--- a/src/slstm_layer.cpp
+++ b/src/slstm_layer.cpp
@@ -578,12 +578,14 @@ void SLSTM::smoother()
     // Clear the LSTM states
     this->time_step = 0;
     this->lstm_states.reset_zeros();
-    // this->smooth_states.reset_zeros();
 }
 
 std::tuple<std::vector<float>, std::vector<float>, std::vector<float>,
            std::vector<float>>
-SLSTM::get_smoothed_lstm_state_at(int timestep) const {
+SLSTM::get_smoothed_lstm_state_at(int timestep)
+    /*
+     */
+    const {
     const auto &smooth = this->smooth_states;
     size_t num_states = smooth.num_states;
     size_t T = smooth.num_timesteps;


### PR DESCRIPTION
## Description

This PR fixes the bug in:
- The smoothing function for hidden states in `slstm_layer`. This avoids negative variances for SLSTM's hidden states.
- The `z_output` smoothing function in the `slinear_layer`. This avoids negative variances for `z_output`.

## Changes Made
- The `smooth_hidden_states` function in `slstm_layer.cpp`
- The `smooth_zo()` function in `slinear_layer.cpp` and `slinear_layer.h`, 
- The `smoother()` function in `sequential.cpp` and `sequential.h`
-  Update `time_series_smoother.py`

## Related Issue(s)

N/A

## Checklist

- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch on the latest upstream code to incorporate any changes.
- [x]  I have tested the changes locally by running `python -m examples.time_series_smoother`
- [x] I have run the corresponding unit tests for smoother in both python and c++.
## Notes for Reviewers
 - Running `python -m examples.time_series_smoother` with `min_v=1e-5`
 - Running `canari` examples with this `cuTAGI` version

